### PR TITLE
Missing _removeExtensionPrimitive method in extension manager causes TypeError

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -797,7 +797,13 @@ class Runtime extends EventEmitter {
     static get EXTENSION_ADDED () {
         return 'EXTENSION_ADDED';
     }
-
+    /**
+     * Event name for reporting that an extension was removed.
+     * @const {string}
+     */
+    static get EXTENSION_REMOVED () {
+        return 'EXTENSION_REMOVED';
+    }
     /**
      * Event name for reporting that an extension as asked for a custom field to be added
      * @const {string}

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1121,6 +1121,31 @@ categoryInfo.blockText = extensionInfo.blockText;
         
         const info = this._blockInfo[extIdx];
         this._blockInfo.splice(extIdx, 1);
+        
+        // Clean up primitives, hats, and flow metadata
+        for (const block of info.blocks) {
+            if (block.json) {
+                const opcode = block.json.type;
+                delete this._primitives[opcode];
+                delete this._hats[opcode];
+                delete this._flowing[opcode];
+            }
+        }
+        
+        // Clean up monitor metadata
+        for (const opcode in this.monitorBlockInfo) {
+            if (opcode.startsWith(extensionId + '_')) {
+                delete this.monitorBlockInfo[opcode];
+            }
+        }
+        
+        // Clean up extension buttons
+        for (const [key] of this.extensionButtons) {
+            if (key.startsWith(extensionId + '_')) {
+                this.extensionButtons.delete(key);
+            }
+        }
+        
         this.emit(Runtime.EXTENSION_REMOVED, extensionId);
         
         // Cleanup blocks from all targets

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1158,14 +1158,21 @@ categoryInfo.blockText = extensionInfo.blockText;
                 const {opcode} = block;
                 if (info.blocks.find(block => block.json?.type === opcode)) {
                     target.blocks.deleteBlock(blockId, true);
-                }
-            }
+// Cleanup blocks from all targets
+for (const target of this.targets) {
+    const blocksToDelete = [];
+    for (const blockId in target.blocks._blocks) {
+        const block = target.blocks.getBlock(blockId);
+        if (!block) continue;
+        const {opcode} = block;
+        if (info.blocks.find(b => b.json?.type === opcode)) {
+            blocksToDelete.push(blockId);
         }
-                if (info.blocks.find(block => block.json?.type === opcode)) {
-                    target.blocks.deleteBlock(blockId, true);
-                }
-            }
-        }
+    }
+    for (const blockId of blocksToDelete) {
+        target.blocks.deleteBlock(blockId, true);
+    }
+}
         this.emit(Runtime.BLOCKS_NEED_UPDATE);
     }
 

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1110,6 +1110,30 @@ categoryInfo.blockText = extensionInfo.blockText;
             this.emit(Runtime.BLOCKSINFO_UPDATE, categoryInfo);
         }
     }
+    /**
+     * Remove an extension's primitives.
+     * @param {string} extensionId - the ID of the extension to remove
+     * @private
+     */
+    _removeExtensionPrimitive(extensionId) {
+        const extIdx = this._blockInfo.findIndex(ext => ext.id === extensionId);
+        if (extIdx === -1) return; // Extension not found
+        
+        const info = this._blockInfo[extIdx];
+        this._blockInfo.splice(extIdx, 1);
+        this.emit(Runtime.EXTENSION_REMOVED, extensionId);
+        
+        // Cleanup blocks from all targets
+        for (const target of this.targets) {
+            for (const blockId in target.blocks._blocks) {
+                const {opcode} = target.blocks.getBlock(blockId);
+                if (info.blocks.find(block => block.json?.type === opcode)) {
+                    target.blocks.deleteBlock(blockId, true);
+                }
+            }
+        }
+        this.emit(Runtime.BLOCKS_NEED_UPDATE);
+    }
 
     /**
      * Read extension information, convert menus, blocks and custom field types

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1151,7 +1151,16 @@ categoryInfo.blockText = extensionInfo.blockText;
         // Cleanup blocks from all targets
         for (const target of this.targets) {
             for (const blockId in target.blocks._blocks) {
-                const {opcode} = target.blocks.getBlock(blockId);
+        for (const target of this.targets) {
+            for (const blockId in target.blocks._blocks) {
+                const block = target.blocks.getBlock(blockId);
+                if (!block) continue;
+                const {opcode} = block;
+                if (info.blocks.find(block => block.json?.type === opcode)) {
+                    target.blocks.deleteBlock(blockId, true);
+                }
+            }
+        }
                 if (info.blocks.find(block => block.json?.type === opcode)) {
                     target.blocks.deleteBlock(blockId, true);
                 }

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1115,65 +1115,66 @@ categoryInfo.blockText = extensionInfo.blockText;
      * @param {string} extensionId - the ID of the extension to remove
      * @private
      */
-    _removeExtensionPrimitive(extensionId) {
+    _removeExtensionPrimitive (extensionId) {
         const extIdx = this._blockInfo.findIndex(ext => ext.id === extensionId);
-        if (extIdx === -1) return; // Extension not found
-        
+        if (extIdx === -1) return;
+
         const info = this._blockInfo[extIdx];
         this._blockInfo.splice(extIdx, 1);
-        
+
         // Clean up primitives, hats, and flow metadata
         for (const block of info.blocks) {
-            if (block.json) {
-                const opcode = block.json.type;
-                delete this._primitives[opcode];
-                delete this._hats[opcode];
-                delete this._flowing[opcode];
-            }
+            const opcode = block.json?.type;
+            if (!opcode) continue;
+            delete this._primitives[opcode];
+            delete this._hats[opcode];
+            delete this._flowing[opcode];
         }
-        
+
+        // Remove compiler extension handle if present
+        if (this[`ext_${extensionId}`]) {
+            delete this[`ext_${extensionId}`];
+        }
+
         // Clean up monitor metadata
         for (const opcode in this.monitorBlockInfo) {
-            if (opcode.startsWith(extensionId + '_')) {
+            if (opcode.startsWith(`${extensionId}_`)) {
                 delete this.monitorBlockInfo[opcode];
             }
         }
-        
-        // Clean up extension buttons
+
+        // Clean up extension buttons (avoid mutating while iterating)
+        const buttonsToDelete = [];
         for (const [key] of this.extensionButtons) {
-            if (key.startsWith(extensionId + '_')) {
-                this.extensionButtons.delete(key);
+            if (key.startsWith(`${extensionId}_`)) {
+                buttonsToDelete.push(key);
             }
         }
-        
-        this.emit(Runtime.EXTENSION_REMOVED, extensionId);
-        
-        // Cleanup blocks from all targets
+        for (const key of buttonsToDelete) {
+            this.extensionButtons.delete(key);
+        }
+
+        // Remove blocks from all targets
         for (const target of this.targets) {
-            for (const blockId in target.blocks._blocks) {
-        for (const target of this.targets) {
+            const blocksToDelete = [];
             for (const blockId in target.blocks._blocks) {
                 const block = target.blocks.getBlock(blockId);
                 if (!block) continue;
                 const {opcode} = block;
-                if (info.blocks.find(block => block.json?.type === opcode)) {
-                    target.blocks.deleteBlock(blockId, true);
-// Cleanup blocks from all targets
-for (const target of this.targets) {
-    const blocksToDelete = [];
-    for (const blockId in target.blocks._blocks) {
-        const block = target.blocks.getBlock(blockId);
-        if (!block) continue;
-        const {opcode} = block;
-        if (info.blocks.find(b => b.json?.type === opcode)) {
-            blocksToDelete.push(blockId);
+                if (info.blocks.some(b => b.json?.type === opcode)) {
+                    blocksToDelete.push(blockId);
+                }
+            }
+            for (const blockId of blocksToDelete) {
+                target.blocks.deleteBlock(blockId, true);
+            }
         }
-    }
-    for (const blockId of blocksToDelete) {
-        target.blocks.deleteBlock(blockId, true);
-    }
-}
+
+        // Refresh caches and UI
+        this.resetAllCaches();
         this.emit(Runtime.BLOCKS_NEED_UPDATE);
+        this.requestToolboxExtensionsUpdate();
+        this.emit(Runtime.EXTENSION_REMOVED, extensionId);
     }
 
     /**

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -51,6 +51,7 @@ const createRuntimeService = runtime => {
     const service = {};
     service._refreshExtensionPrimitives = runtime._refreshExtensionPrimitives.bind(runtime);
     service._registerExtensionPrimitives = runtime._registerExtensionPrimitives.bind(runtime);
+    service._removeExtensionPrimitive = runtime._removeExtensionPrimitive.bind(runtime);  // Add this line
     return service;
 };
 

--- a/src/virtual-machine.js
+++ b/src/virtual-machine.js
@@ -140,6 +140,10 @@ class VirtualMachine extends EventEmitter {
         this.runtime.on(Runtime.TOOLBOX_EXTENSIONS_NEED_UPDATE, () => {
             this.extensionManager.refreshBlocks();
         });
+        this.runtime.on(Runtime.EXTENSION_REMOVED, extensionId => {
+            this.emit(Runtime.EXTENSION_REMOVED, extensionId);
+            this.extensionManager.refreshBlocks();
+        });
         this.runtime.on(Runtime.PERIPHERAL_LIST_UPDATE, info => {
             this.emit(Runtime.PERIPHERAL_LIST_UPDATE, info);
         });


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
https://github.com/OmniBlocks/scratch-vm/issues/10
### Proposed Changes
## Problem

After adding `core/field_customInput.js` to scratch-blocks (to support sp_javascriptV2 extension's code editor), the editor fails to load with the following error:

```
Error (splash) in https://omniblocks.github.io/scratch-gui/supervoidcoder/159/js/pentapod/vendors~editor~embed~fullscreen~player.6c04291d4bc814103b63.js (2:4881995): 
TypeError: can't access property "bind", e._removeExtensionPrimitive is undefined
```

## Context

- This error appeared after adding `field_customInput.js` to enable the JavaScript extension's code editor UI
- The error suggests that the `_removeExtensionPrimitive` method is missing from the extension manager
- Related to implementing sp_javascriptV2 extension

## Investigation Notes

The `_removeExtensionPrimitive` method is used for extension cleanup/unloading. PenguinMod and TurboWarp VMs have this method in their extension managers. It likely needs to be backported to OmniBlocks/scratch-vm.

**Suggested fix:** Check PenguinMod-Vm and TurboWarp's `extension-manager.js` for the `_removeExtensionPrimitive` implementation and add it to OmniBlocks' VM.

## Related

- Original issue: OmniBlocks/monorepo#165
- PR implementing JavaScript extension UI: OmniBlocks/scratch-gui#159
- Reported by: @supervoidcoder
_Describe what this Pull Request does_

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_
